### PR TITLE
Removing maximize window calls inside default steps due to docker issue

### DIFF
--- a/src/step_defs/page.js
+++ b/src/step_defs/page.js
@@ -9,7 +9,6 @@ var pageSteps = function () {
      */
     this.Given(/^user navigates to '(.*)'$/, function (url) {
         var gotourl = helperCommon.getTreatedValue(url);
-        browser.driver.manage().window().maximize();
         return browser.get(gotourl);
     });
 
@@ -25,7 +24,6 @@ var pageSteps = function () {
         var server = gotourl.substring(gotourl.indexOf("//") + 2);
         var urlAuth = `http://${myuser}:${mypass}@${server}`;
 
-        browser.driver.manage().window().maximize();
         return browser.get(urlAuth);
     });
 


### PR DESCRIPTION
Due to Docker issue in maximizing a browser window, need to remove these lines.
So now, to maximize window, need to add an capabilitie args to protractor.conf.js: 'start-maximized' to start the browser maximized